### PR TITLE
Fix to get this working

### DIFF
--- a/compose.wac
+++ b/compose.wac
@@ -11,4 +11,4 @@ let r = new component:router2 {
     ...
 };
 
-export r as "wasi:http/incoming-handler@0.2.0";
+export r...;

--- a/router2/src/lib.rs
+++ b/router2/src/lib.rs
@@ -12,7 +12,11 @@ impl Guest for Component {
         rf.add("/auth", Handler::new(auth_handler)).expect("should have added route");
         rf.add("/greet", Handler::new(greet_handler)).expect("should have added route");
         rf.add("/*", Handler::new(not_found_handler)).expect("should have added route");
-        let handler = rf.get_handler(request.path_with_query().expect("should have a path")).expect("path should have matched a route");
+
+        let request_path = request.path_with_query().expect("should have a path");
+        let handler = rf
+            .best_match(&request_path)
+            .expect("path should have matched a route");
 
         handler.invoke(request, response_out);
     }


### PR DESCRIPTION
It took me an embarrassing amount of time to realize why my `println!`s weren't working in `router2` because we are building that component with `wasm32-unknown-unknown`. If building with `wasm32-wasi` we would have seen the `panic!` indicating that the `routefinder::Router` wasn't finding a matching route.

TIL: `routefinder::Router::get_handler` doesn't match a path against a route pattern; it expects the explicit pattern as input, i.e. `/*`

Alternatively instead of `export r...;` you could `export r["wasi:http/incoming-handler@0.2.0"];` to achieve the same result.